### PR TITLE
print full 'consider' string when analyzing cache

### DIFF
--- a/kstat-analyzer
+++ b/kstat-analyzer
@@ -583,7 +583,7 @@ def cache_analysis(kstats, cache_name, hits_key, misses_key, consider):
             pr_analysis('{} cache hit rate > {:.0f}%'.format(
                 cache_name, CACHE_RATIO_OK * 100), status='ok')
         else:
-            pr_analysis('{} cache hit rate < {:.0f}%, consider'.format(
+            pr_analysis('{} cache hit rate < {:.0f}%, consider {}'.format(
                 cache_name, CACHE_RATIO_OK * 100, consider), status='info')
 
 


### PR DESCRIPTION
e.g., when prefetch hit rates are low we want to print

   + Analysis: status=info: Prefetch metadata cache hit rate < 25%, consider updating metadata cache strategy

not
   + Analysis: status=info: Prefetch metadata cache hit rate < 25%, consider

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com<